### PR TITLE
feat: allow user to specify more than one database, or to take backup of all databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,14 @@ Easily back up from cloudSQL or any mysql instance to AWS S3.
 
 | Variable                          |  Description                         |
 |-----------------------------------|--------------------------------------|
-| `MYSQL_HOST`                      | Mysql host                           | 
+| `MYSQL_HOST`                      | Mysql host                           |
 | `MYSQL_PORT`                      | Mysql port                           |
-| `MYSQL_DATABASE`                  | Mysql target database                |
+| `MYSQL_DATABASE`                  | Mysql target databases.              |
+|                                   | Space-separated if more than one db, |
+|                                   | e.g. MYSQL_DATABASE="db-1 db-2 db3". |
+|                                   | If empty or not defined - will try   |
+|                                   | to dump all databases by using       |
+|                                   | mysqldump --all-databases flag       |
 | `MYSQL_USER`                      | Mysql user                           |
 | `MYSQL_PASSWORD`                  | Mysql password                       |
 | `AWS_ACCESS_KEY_ID`               | AWS S3 accessKeyId                   |
@@ -15,7 +20,9 @@ Easily back up from cloudSQL or any mysql instance to AWS S3.
 | `AWS_S3_FILE_PREFIX`              | Prefix to generate AWS s3 file name  |
 | `AWS_S3_BUCKET`                   | Target S3 bucket                     |
 | `AWS_ENDPOINT_URL`                | Override S3 URL with the given URL   |
-| `GOOGLE_APPLICATION_CREDENTIALS`  | GCP json credentials                 |
+| `GOOGLE_APPLICATION_CREDENTIALS`  | GCP json credentials file path       |
+|                                   | You can mount this file as container |
+|                                   | volume                               |
 | `GCP_GCS_FILE_PREFIX`             | Prefix to generate GCP gcs file name |
 | `GCP_GCS_BUCKET`                  | Target GCS bucket                    |
 

--- a/rootfs/mysql2storage
+++ b/rootfs/mysql2storage
@@ -5,7 +5,13 @@ filename=$(mktemp)
 
 echo "[$(date -Iseconds)] Started mysqldump"
 
-mysqldump -h "${MYSQL_HOST}" -P "${MYSQL_PORT}" -u "${MYSQL_USER}" -p"${MYSQL_PASSWORD}" "${MYSQL_DATABASE}" > "${filename}"
+if [ -z "$MYSQL_DATABASE" ]; then
+	MYSQL_DATABASE="--all-databases"
+else
+	MYSQL_DATABASE="--databases ${MYSQL_DATABASE}"
+fi
+
+mysqldump -h "${MYSQL_HOST}" -P "${MYSQL_PORT}" -u "${MYSQL_USER}" -p"${MYSQL_PASSWORD}" ${MYSQL_DATABASE} > "${filename}"
 
 echo "[$(date -Iseconds)] Compressing mysqldump"
 


### PR DESCRIPTION
This PR gives user the possibility to specify more than one database to backup. If DB name is ommited, then all databases will be backed up.

I have tested this change against all 3 scenarios:

1. Env variable MYSQL_DATABASE not set in Docker CLI params. Container backed up all databases
2. Env variable set to MYSQL_DATABASE=db1 Container backed up only one database
3. Env variable set to MYSQL_DATABASE="db1 db2 db3" Container backed up all mentioned 3 databases

Tomorrow, I will also provide corresponding PR to https://github.com/softonic/mysql-backup-chart repository. However it would be better, to have this change released as container image 0.4.0 beforehands.